### PR TITLE
fix minor bug for celltk-preprocess

### DIFF
--- a/celltk/utils/mi_align.py
+++ b/celltk/utils/mi_align.py
@@ -11,7 +11,8 @@ import scipy
 from skimage.measure import block_reduce
 from scipy.ndimage.filters import gaussian_laplace
 from skimage.exposure import equalize_adapthist, equalize_hist
-from utils.imreg import translation
+#from utils.imreg import translation
+from imreg import translation
 from scipy.ndimage import imread
 # from numba.decorators import jit
 from centrosome.filter import stretch


### PR DESCRIPTION
celltk-preprocessのコマンドでimportエラーが出るので、直しました。
mi_align.pyのcalc_jittersがpreprocess_operationsで使われてないので、本体には影響ないとは思いますが。